### PR TITLE
Fix crashed process when request from browser on dev mode

### DIFF
--- a/renderer/_default.page.server.tsx
+++ b/renderer/_default.page.server.tsx
@@ -20,9 +20,6 @@ export async function render(pageContext: PageContextBuiltIn & PageContext) {
   const { initialCompletion, totalCompletion, pipe, getStoreSource } =
     renderReact(pageContext)
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  totalCompletion.catch(() => {}) // ignored for now, I don't have any idea how to handle this
-
   // Merge config's head data and page's head data
   const { pageExports } = pageContext
   const headTags: string[] = []
@@ -67,9 +64,11 @@ export async function render(pageContext: PageContextBuiltIn & PageContext) {
     documentHtml,
     // Sends Relay store data to client, after the streaming ends.
     // This ensures that the store data is extracted after getting filled with fetched data.
-    pageContext: totalCompletion.then(() => ({
-      relayInitialData: getStoreSource().toJSON(),
-    })),
+    pageContext: totalCompletion
+        .then(() => ({
+          relayInitialData: getStoreSource().toJSON(),
+        }))
+        .catch(() => ({})),
   }
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
-import { createServer } from 'http'
-import { createApp } from 'h3'
-import serveStatic from 'serve-static'
+import { createApp, sendError } from 'h3'
+import { createServer, IncomingMessage, ServerResponse } from 'http'
 import path from 'path'
+import serveStatic from 'serve-static'
 import { createPageRenderer } from 'vite-plugin-ssr'
 
 const isProduction = process.env.NODE_ENV === 'production'
@@ -10,7 +10,7 @@ const root = path.join(__dirname, '..')
 startServer()
 
 async function startServer() {
-  const app = createApp()
+  const app = createApp({ onError })
 
   let viteDevServer
   if (isProduction) {
@@ -40,4 +40,12 @@ async function startServer() {
   const port = process.env.PORT || 3000
   createServer(app).listen(port)
   console.log(`Server running at http://localhost:${port}`)
+}
+
+function onError(error: Error, req: IncomingMessage, res: ServerResponse) {
+  if (res.headersSent) {
+    res.end()
+    return
+  }
+  sendError(res, error, false)
 }


### PR DESCRIPTION
Fix https://github.com/XiNiHa/vite-ssr-relay-template/issues/1

Modified it `totalCompletion` to return an empty object when it failed, and changed the `h3` server's `onError` option to complete the response if the header has already been sent.

ps. New request occurs due to an error and `null` is returned when `useContext(ReactRelayContext)` is called. In addition, resource requests that did not handled on viteDevServer.middlewares are being passed to renderPage requests.